### PR TITLE
Add profile manager and store table data in JSON

### DIFF
--- a/profile_manager.py
+++ b/profile_manager.py
@@ -1,0 +1,91 @@
+import argparse
+import json
+from pathlib import Path
+from bs4 import BeautifulSoup
+
+PROFILES_FILE = Path('profiles.json')
+TABLE_FILE = Path('table.json')
+
+
+def load_profiles():
+    if PROFILES_FILE.exists():
+        with PROFILES_FILE.open() as f:
+            return json.load(f)
+    return []
+
+
+def save_profiles(profiles):
+    with PROFILES_FILE.open('w') as f:
+        json.dump(profiles, f, indent=2)
+
+
+def add_profile(args):
+    profiles = load_profiles()
+    profile = {
+        'name': args.name,
+        'annual_income': args.income,
+        'filing_status': args.filing_status,
+        'dependents': args.dependents,
+        'deduction_type': args.deduction_type,
+        'state': args.state,
+    }
+    profiles.append(profile)
+    save_profiles(profiles)
+    print(f"Added profile for {args.name}")
+
+
+def list_profiles(_args):
+    profiles = load_profiles()
+    if not profiles:
+        print('No profiles stored.')
+        return
+    for p in profiles:
+        print(json.dumps(p, indent=2))
+
+
+def table_to_json(args):
+    html_path = Path(args.html)
+    with html_path.open() as f:
+        soup = BeautifulSoup(f, 'html.parser')
+    table = soup.find('table')
+    header_cells = table.find('tr').find_all(['th', 'td'])
+    headers = [h.get_text(strip=True) for h in header_cells]
+    rows = []
+    for tr in table.find_all('tr')[1:]:
+        cells = [td.get_text(strip=True) for td in tr.find_all('td')]
+        if cells:
+            rows.append(dict(zip(headers, cells)))
+    with TABLE_FILE.open('w') as f:
+        json.dump(rows, f, indent=2)
+    print(f"Saved {len(rows)} rows to {TABLE_FILE}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Manage profiles and table data')
+    sub = parser.add_subparsers(dest='command')
+
+    add_p = sub.add_parser('add-profile', help='Add a profile')
+    add_p.add_argument('--name', required=True)
+    add_p.add_argument('--income', type=float, required=True)
+    add_p.add_argument('--filing-status', required=True, dest='filing_status')
+    add_p.add_argument('--dependents', type=int, default=0)
+    add_p.add_argument('--deduction-type', default='standard', dest='deduction_type')
+    add_p.add_argument('--state', default='')
+    add_p.set_defaults(func=add_profile)
+
+    list_p = sub.add_parser('list-profiles', help='List profiles')
+    list_p.set_defaults(func=list_profiles)
+
+    t2j = sub.add_parser('table-to-json', help='Convert table HTML to JSON')
+    t2j.add_argument('--html', default='index.html')
+    t2j.set_defaults(func=table_to_json)
+
+    args = parser.parse_args()
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/profiles.json
+++ b/profiles.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Alice",
+    "annual_income": 80000.0,
+    "filing_status": "single",
+    "dependents": 0,
+    "deduction_type": "standard",
+    "state": "NY"
+  },
+  {
+    "name": "Bob",
+    "annual_income": 120000.0,
+    "filing_status": "married",
+    "dependents": 2,
+    "deduction_type": "itemized",
+    "state": "CA"
+  }
+]

--- a/table.json
+++ b/table.json
@@ -1,0 +1,149 @@
+[
+  {
+    "Rank": "1\ufe0f\u20e3",
+    "Neighborhood": "North Downtown",
+    "Location": "Charlottesville, VA",
+    "New Score (/27)": "24",
+    "Notes": "VA\u2019s moderate taxes"
+  },
+  {
+    "Rank": "2\ufe0f\u20e3",
+    "Neighborhood": "Belmont",
+    "Location": "Charlottesville, VA",
+    "New Score (/27)": "23",
+    "Notes": "VA"
+  },
+  {
+    "Rank": "2\ufe0f\u20e3",
+    "Neighborhood": "Old Town Historic",
+    "Location": "Harrisonburg, VA",
+    "New Score (/27)": "23",
+    "Notes": "VA"
+  },
+  {
+    "Rank": "2\ufe0f\u20e3",
+    "Neighborhood": "Kenilworth",
+    "Location": "Asheville, NC",
+    "New Score (/27)": "23",
+    "Notes": "NC"
+  },
+  {
+    "Rank": "5\ufe0f\u20e3",
+    "Neighborhood": "Five Points",
+    "Location": "Asheville, NC",
+    "New Score (/27)": "22",
+    "Notes": "NC"
+  },
+  {
+    "Rank": "5\ufe0f\u20e3",
+    "Neighborhood": "Montford",
+    "Location": "Asheville, NC",
+    "New Score (/27)": "22",
+    "Notes": "NC"
+  },
+  {
+    "Rank": "5\ufe0f\u20e3",
+    "Neighborhood": "Chapel Hill Village",
+    "Location": "Chapel Hill, NC",
+    "New Score (/27)": "~22",
+    "Notes": "NC"
+  },
+  {
+    "Rank": "5\ufe0f\u20e3",
+    "Neighborhood": "Murray Hill",
+    "Location": "Annapolis, MD",
+    "New Score (/27)": "21.5",
+    "Notes": "MD mixed taxes"
+  },
+  {
+    "Rank": "5\ufe0f\u20e3",
+    "Neighborhood": "Ardmore",
+    "Location": "Ardmore, PA",
+    "New Score (/27)": "~21",
+    "Notes": "PA high taxes drag down score"
+  },
+  {
+    "Rank": "5\ufe0f\u20e3",
+    "Neighborhood": "Oakhurst",
+    "Location": "Decatur, GA",
+    "New Score (/27)": "22",
+    "Notes": "GA moderate taxes"
+  },
+  {
+    "Rank": "\ud83d\udd1f",
+    "Neighborhood": "Candler Park",
+    "Location": "Atlanta, GA",
+    "New Score (/27)": "~21.5",
+    "Notes": "GA"
+  },
+  {
+    "Rank": "\ud83d\udd1f",
+    "Neighborhood": "Athens Historic",
+    "Location": "Athens, GA",
+    "New Score (/27)": "~21.5",
+    "Notes": "GA"
+  },
+  {
+    "Rank": "\ud83d\udd1f",
+    "Neighborhood": "Greenville Heights",
+    "Location": "Greenville, SC",
+    "New Score (/27)": "~21.5",
+    "Notes": "SC"
+  },
+  {
+    "Rank": "\ud83d\udd1f",
+    "Neighborhood": "Mount Airy",
+    "Location": "Philadelphia, PA",
+    "New Score (/27)": "20.5",
+    "Notes": "PA"
+  },
+  {
+    "Rank": "\ud83d\udd1f",
+    "Neighborhood": "Carolina Heights",
+    "Location": "Wilmington, NC",
+    "New Score (/27)": "21.5",
+    "Notes": "NC"
+  },
+  {
+    "Rank": "15",
+    "Neighborhood": "Oakwood",
+    "Location": "Raleigh, NC",
+    "New Score (/27)": "21",
+    "Notes": "NC"
+  },
+  {
+    "Rank": "15",
+    "Neighborhood": "The Fan",
+    "Location": "Richmond, VA",
+    "New Score (/27)": "21",
+    "Notes": "VA"
+  },
+  {
+    "Rank": "15",
+    "Neighborhood": "Bellevue",
+    "Location": "Richmond, VA",
+    "New Score (/27)": "21",
+    "Notes": "VA"
+  },
+  {
+    "Rank": "15",
+    "Neighborhood": "Westover Hills",
+    "Location": "Richmond, VA",
+    "New Score (/27)": "21",
+    "Notes": "VA"
+  },
+  {
+    "Rank": "19",
+    "Neighborhood": "Riverside",
+    "Location": "Jacksonville, FL",
+    "New Score (/27)": "~20.5",
+    "Notes": "FL no income tax"
+  },
+  {
+    "Rank": "19",
+    "Neighborhood": "Reston (Lake Anne)",
+    "Location": "Reston, VA",
+    "New Score (/27)": "20.5",
+    "Notes": "VA"
+  }
+]


### PR DESCRIPTION
## Summary
- create `profile_manager.py` with subcommands to add/list profiles and convert the existing neighborhood table to JSON
- include generated `profiles.json` with sample entries
- include `table.json` converted from `index.html`

## Testing
- `python3 profile_manager.py table-to-json --html index.html`
- `python3 profile_manager.py add-profile --name Alice --income 80000 --filing-status single --dependents 0 --deduction-type standard --state NY`
- `python3 profile_manager.py add-profile --name Bob --income 120000 --filing-status married --dependents 2 --deduction-type itemized --state CA`
- `python3 profile_manager.py list-profiles`


------
https://chatgpt.com/codex/tasks/task_e_687c123014948327b70932017fe5c22c