### PR TITLE
Add daily metrics helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ Columns in the table:
 - **Notes** – contextual notes (e.g., tax situations).
 
 These files are static and intended only for reference.
+
+## Metrics
+
+The `metrics.py` helper aggregates recordings or event logs to simple counts per day. Provide a JSON lines or CSV file containing a `timestamp` (or `date`) field for each recording:
+
+```bash
+python metrics.py recordings.jsonl
+```
+
+This prints one line per day with the number of records observed on that date.

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,58 @@
+import argparse
+import csv
+import json
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Aggregate metric counts per day")
+    parser.add_argument("file", help="Input file containing recordings")
+    parser.add_argument("--format", choices=["json", "csv"], default="json",
+                        help="Format of the input file: json lines or CSV")
+    return parser.parse_args()
+
+
+def load_records(path: Path, fmt: str):
+    if fmt == "json":
+        with path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                yield json.loads(line)
+    else:
+        with path.open() as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                yield row
+
+
+def metric_counts_per_day(records):
+    counts = defaultdict(int)
+    for rec in records:
+        ts = rec.get("timestamp") or rec.get("date")
+        if not ts:
+            continue
+        try:
+            dt = datetime.fromisoformat(ts)
+        except ValueError:
+            # if date only, just parse that
+            dt = datetime.fromisoformat(ts + "T00:00:00")
+        day = dt.date().isoformat()
+        counts[day] += 1
+    return counts
+
+
+def main():
+    args = parse_args()
+    path = Path(args.file)
+    records = list(load_records(path, args.format))
+    counts = metric_counts_per_day(records)
+    for day in sorted(counts):
+        print(f"{day} {counts[day]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/recordings.jsonl
+++ b/recordings.jsonl
@@ -1,0 +1,5 @@
+{"timestamp": "2025-07-01T10:00:00", "value": 5}
+{"timestamp": "2025-07-01T12:00:00", "value": 3}
+{"timestamp": "2025-07-02T09:00:00", "value": 2}
+{"timestamp": "2025-07-02T15:00:00", "value": 4}
+{"timestamp": "2025-07-03T14:00:00", "value": 1}


### PR DESCRIPTION
## Summary
- implement `metrics.py` for aggregating counts per day
- document the new script in README
- add example dataset `recordings.jsonl`

## Testing
- `python3 metrics.py recordings.jsonl`
- `python3 -m py_compile metrics.py profile_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_687c1a359c48832797ea25e861277420