### PR TITLE
Add optional JSON output to metrics script

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -9,8 +9,17 @@ from pathlib import Path
 def parse_args():
     parser = argparse.ArgumentParser(description="Aggregate metric counts per day")
     parser.add_argument("file", help="Input file containing recordings")
-    parser.add_argument("--format", choices=["json", "csv"], default="json",
-                        help="Format of the input file: json lines or CSV")
+    parser.add_argument(
+        "--format",
+        choices=["json", "csv"],
+        default="json",
+        help="Format of the input file: json lines or CSV",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the aggregated counts as JSON",
+    )
     return parser.parse_args()
 
 
@@ -45,13 +54,22 @@ def metric_counts_per_day(records):
     return counts
 
 
+def write_counts(counts, path: Path) -> None:
+    """Write ``counts`` mapping to ``path`` in JSON format."""
+    with path.open("w") as f:
+        json.dump(dict(counts), f, indent=2)
+
+
 def main():
     args = parse_args()
     path = Path(args.file)
     records = list(load_records(path, args.format))
     counts = metric_counts_per_day(records)
-    for day in sorted(counts):
-        print(f"{day} {counts[day]}")
+    if args.output:
+        write_counts(counts, args.output)
+    else:
+        for day in sorted(counts):
+            print(f"{day} {counts[day]}")
 
 
 if __name__ == "__main__":

--- a/test_metrics.py
+++ b/test_metrics.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from metrics import metric_counts_per_day, write_counts
+
+
+def test_metric_counts_per_day_and_write(tmp_path: Path) -> None:
+    records = [
+        {"timestamp": "2024-04-01T12:00:00"},
+        {"date": "2024-04-01"},
+        {"timestamp": "2024-04-02T00:00:00"},
+    ]
+
+    counts = metric_counts_per_day(records)
+    assert counts == {"2024-04-01": 2, "2024-04-02": 1}
+
+    out_file = tmp_path / "counts.json"
+    write_counts(counts, out_file)
+    data = json.loads(out_file.read_text())
+    assert data == counts
+


### PR DESCRIPTION
## Summary
- allow metrics script to write aggregated counts to a JSON file via new `--output` option
- add helper to dump counts
- test metric aggregation and output writing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a923f78dc8832791d4da05488b50ef