### PR TITLE
Add dream-inspired ASCII star field script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ python metrics.py recordings.jsonl
 ```
 
 This prints one line per day with the number of records observed on that date.
+
+## Dream Script
+
+The `dream.py` program prints a randomly generated field of ASCII stars—
+a tiny fragment of a cosmic dream rendered in the terminal.

--- a/dream.py
+++ b/dream.py
@@ -1,0 +1,26 @@
+"""Dream a little dream of ASCII stars.
+
+This script prints a randomly generated field of stars to the terminal.
+"""
+
+import random
+
+
+def generate_star_field(width: int = 40, height: int = 10, density: float = 0.15) -> str:
+    """Return a string representing a field of stars.
+
+    Args:
+        width: The number of characters in each line.
+        height: The number of lines to generate.
+        density: The probability that any given character will be a star.
+    """
+    rows = []
+    for _ in range(height):
+        row = ''.join('*' if random.random() < density else ' ' for _ in range(width))
+        rows.append(row)
+    return "\n".join(rows)
+
+
+if __name__ == "__main__":
+    print("I drift into a cosmic dream...\n")
+    print(generate_star_field())


### PR DESCRIPTION
## Summary
- introduce `dream.py` script that generates a random ASCII star field
- document the new dreamy script in the README

## Testing
- `python -m py_compile dream.py`
- `python dream.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9f7b4959c832790df78e8605fd21d