### PR TITLE
Add CSV export for metric counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ python metrics.py recordings.jsonl
 ```
 
 This prints one line per day with the number of records observed on that date.
+Pass ``--output`` with a ``.json`` or ``.csv`` file to write the aggregated
+counts in that format instead of printing them.
 
 ## Dream Script
 

--- a/metrics.py
+++ b/metrics.py
@@ -18,7 +18,7 @@ def parse_args():
     parser.add_argument(
         "--output",
         type=Path,
-        help="Optional path to write the aggregated counts as JSON",
+        help="Optional path to write the aggregated counts as JSON or CSV",
     )
     return parser.parse_args()
 
@@ -55,9 +55,21 @@ def metric_counts_per_day(records):
 
 
 def write_counts(counts, path: Path) -> None:
-    """Write ``counts`` mapping to ``path`` in JSON format."""
-    with path.open("w") as f:
-        json.dump(dict(counts), f, indent=2)
+    """Write ``counts`` mapping to ``path``.
+
+    The format is determined by the file suffix: ``.json`` produces a JSON
+    object mapping days to counts, while ``.csv`` writes a two-column CSV with
+    ``date`` and ``count`` headers.
+    """
+
+    with path.open("w", newline="") as f:
+        if path.suffix == ".csv":
+            writer = csv.writer(f)
+            writer.writerow(["date", "count"])
+            for day, count in sorted(counts.items()):
+                writer.writerow([day, count])
+        else:
+            json.dump(dict(counts), f, indent=2)
 
 
 def main():

--- a/test_metrics.py
+++ b/test_metrics.py
@@ -1,3 +1,4 @@
+import csv
 import json
 from pathlib import Path
 
@@ -20,4 +21,16 @@ def test_metric_counts_per_day_and_write(tmp_path: Path) -> None:
     write_counts(counts, out_file)
     data = json.loads(out_file.read_text())
     assert data == counts
+
+
+def test_write_counts_csv(tmp_path: Path) -> None:
+    counts = {"2024-04-01": 2, "2024-04-02": 1}
+    out_file = tmp_path / "counts.csv"
+    write_counts(counts, out_file)
+    with out_file.open() as f:
+        rows = list(csv.DictReader(f))
+    assert rows == [
+        {"date": "2024-04-01", "count": "2"},
+        {"date": "2024-04-02", "count": "1"},
+    ]
 


### PR DESCRIPTION
## Summary
- Support CSV output in `metrics.py` based on file extension
- Document `--output` usage for CSV or JSON writing
- Test CSV writing alongside existing JSON behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa0616fd5c8327827bfbe1fc22a677