### PR TITLE
Add codex-friendly novel scaffolding and README documentation

### DIFF
--- a/00_outline.md
+++ b/00_outline.md
@@ -1,0 +1,14 @@
+# Novel Outline
+
+## Act Structure
+- Act I:
+  - TODO: Establish setting, protagonist, and inciting incident.
+- Act II:
+  - TODO: Escalate conflict, deepen stakes, and introduce complications.
+- Act III:
+  - TODO: Resolve core conflict and close character arcs.
+
+## Chapter Map
+1. Chapter 1: TODO
+2. Chapter 2: TODO
+3. Chapter 3: TODO

--- a/01_ch01.md
+++ b/01_ch01.md
@@ -1,0 +1,13 @@
+# Chapter 1: TODO Title
+
+## Context
+- Timeline position: TODO
+- POV: TODO
+- Location: TODO
+- Key state (before): TODO
+- Key state (after): TODO
+- Continuity notes / open threads: TODO
+
+## Draft
+
+TODO: Write chapter text.

--- a/02_ch02.md
+++ b/02_ch02.md
@@ -1,0 +1,13 @@
+# Chapter 2: TODO Title
+
+## Context
+- Timeline position: TODO
+- POV: TODO
+- Location: TODO
+- Key state (before): TODO
+- Key state (after): TODO
+- Continuity notes / open threads: TODO
+
+## Draft
+
+TODO: Write chapter text.

--- a/03_ch03.md
+++ b/03_ch03.md
@@ -1,0 +1,13 @@
+# Chapter 3: TODO Title
+
+## Context
+- Timeline position: TODO
+- POV: TODO
+- Location: TODO
+- Key state (before): TODO
+- Key state (after): TODO
+- Continuity notes / open threads: TODO
+
+## Draft
+
+TODO: Write chapter text.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,48 @@ Columns in the table:
 
 These files are static and intended only for reference.
 
+## Codex-Friendly Novel Structure
+
+This project now includes a lightweight novel workspace with a structure designed
+for Codex-friendly chunking.
+
+**Recommended file layout**
+
+- `00_outline.md` – act-level outline and chapter map.
+- `series_bible.md` – characters, settings, timeline, rules.
+- `glossary.md` – key terms, names, recurring motifs.
+- `continuity_log.md` – track retcons and major changes.
+- `01_ch01.md`, `02_ch02.md`, `03_ch03.md` – one chapter per file.
+
+**Chapter file template**
+
+Each chapter starts with a small context header so the file is editable in
+isolation:
+
+```
+# Chapter X: Title
+## Context
+- Timeline position:
+- POV:
+- Location:
+- Key state (before):
+- Key state (after):
+- Continuity notes / open threads:
+```
+
+### Principles
+
+1. Keep files small and coherent (1–3k words when possible).
+2. Include a context header in every chapter/scene file.
+3. Use consistent filenames with numeric prefixes for ordering.
+4. Maintain a single source of truth for canon in `series_bible.md`.
+5. Record major changes in `continuity_log.md`.
+6. Restate critical dependencies in the current file.
+7. Track open threads in the context header.
+8. Avoid multi-POV or multi-location jumps in a single file.
+9. Summarize transitions in the context header when needed.
+10. Prefer explicit structure over hidden conventions.
+
 ## Metrics
 
 The `metrics.py` helper aggregates recordings or event logs to simple counts per day. Provide a JSON lines or CSV file containing a `timestamp` (or `date`) field for each recording:

--- a/continuity_log.md
+++ b/continuity_log.md
@@ -1,0 +1,4 @@
+# Continuity Log
+
+## YYYY-MM-DD
+- TODO: Document major changes, retcons, or fixes.

--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,3 @@
+# Glossary
+
+- TODO: Key terms, proper nouns, and recurring motifs.

--- a/series_bible.md
+++ b/series_bible.md
@@ -1,0 +1,13 @@
+# Series Bible
+
+## Characters
+- TODO: Character name, role, and arc.
+
+## Settings
+- TODO: Key locations and sensory details.
+
+## Timeline
+- TODO: Important dates and sequence of events.
+
+## Rules & Lore
+- TODO: Constraints, world rules, and canon decisions.


### PR DESCRIPTION
### Motivation

- Provide a lightweight novel workspace organized for Codex-friendly chunking and isolated editing.
- Make it easy to track canon, continuity, and recurring terms across chapter files.
- Document a recommended file layout and authoring principles directly in the repository README.

### Description

- Add scaffold files: `00_outline.md`, `01_ch01.md`, `02_ch02.md`, `03_ch03.md`, `series_bible.md`, `glossary.md`, and `continuity_log.md` as placeholder templates with TODOs.
- Update `README.md` with a new "Codex-Friendly Novel Structure" section that documents recommended layout, a chapter file template, and authoring principles.
- Ensure each chapter file contains a small `## Context` header to make files editable in isolation and to record state and open threads.
- Keep files intentionally small and explicit to support chunked generation and single-source-of-truth canon management.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be6cf07088327b98ffa987bf6ff45)