### PR TITLE
Add Codex-friendly chunking strategy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,56 @@ These guidelines should be consulted before any new writing or revisions.
 - Maintain a living list of characters, relationships, and key events.
 - Track dates, ages, and geographic movement for consistency.
 - Reconfirm tone alignment with these guidelines after each major draft.
+
+## Codex-Friendly Chunk Strategy
+Design the manuscript so each file is small, coherent, and self-contained.
+
+### Chunking Options
+Choose a structure that fits your draft stage:
+- **Outline + Chapters**
+  - `00_outline.md` (global outline, act structure, key beats)
+  - `01_ch01.md`, `02_ch02.md`, ...
+- **Outline + Scenes**
+  - `00_outline.md`
+  - `scenes/01a_scene.md`, `scenes/01b_scene.md`, ...
+- **Outline + Acts + Chapters**
+  - `00_outline.md`
+  - `act1/01_ch01.md`, `act1/02_ch02.md`, ...
+  - `act2/...`, `act3/...`
+
+### Per-File Header Template
+Add a short context header at the top of every chapter/scene file:
+
+```
+# Chapter X: Title
+## Context
+- Timeline position:
+- POV:
+- Location:
+- Key state (before):
+- Key state (after):
+- Continuity notes / open threads:
+```
+
+### Supporting Reference Files
+Keep continuity centralized and explicit:
+- `series_bible.md` (characters, settings, timeline, lore, rules)
+- `glossary.md` (names, terms, recurring motifs)
+- `continuity_log.md` (decisions, retcons, changes)
+
+### Naming and Size Guidance
+- Use numeric prefixes for sorting: `00_outline.md`, `01_ch01.md`, ...
+- Avoid spaces; prefer underscores.
+- Target **1,000–3,000 words** per file, smaller for complex scenes.
+
+### Principles for Codex-Friendly Drafting
+- **Self-contained files:** Ensure each file can be edited in isolation.
+- **Stable structure:** Keep headers consistent and predictable.
+- **Small, coherent units:** Prefer short chapters or single-scene files.
+- **Single source of truth:** Update the series bible and continuity log.
+- **Explicit transitions:** Summarize what changed from the prior file.
+- **Consistent naming:** Preserve ordering with numeric prefixes.
+- **Track unresolved threads:** List open questions in every header.
+- **Avoid hidden dependencies:** Restate required details briefly.
+- **Minimize scope drift:** Keep to one POV/time/location when possible.
+- **Document changes:** Log revisions and retcons immediately.


### PR DESCRIPTION
### Motivation
- Provide a clear, Codex-oriented approach for dividing the manuscript into small, self-contained files so the model can edit and reason locally. 
- Supply consistent templates, naming, and supporting reference files to reduce hidden dependencies and improve continuity. 
- Encourage a single source of truth and explicit transitions to make cross-file edits safer and more traceable. 
- Offer practical size and structure guidance to fit automated workflows and human reviewers.

### Description
- Added a new "Codex-Friendly Chunk Strategy" section to `README.md` describing chunking options (outline+chapters, outline+scenes, outline+acts+chapters). 
- Inserted a per-file header template that lists `Timeline position`, `POV`, `Location`, `Key state (before/after)`, and `Continuity notes / open threads` for each chapter/scene file. 
- Documented supporting reference files `series_bible.md`, `glossary.md`, and `continuity_log.md`, plus naming guidance (numeric prefixes) and target file sizes (`1,000–3,000` words). 
- Added a concise set of drafting principles for Codex-friendly editing, including self-contained files, stable structure, explicit transitions, and change documentation.

### Testing
- This is a documentation-only change to `README.md`, so no automated unit tests were executed. 
- No CI or test failures were reported as part of the rollout. 
- The change does not affect runtime code paths and requires no additional test updates. 
- Manual review of the updated `README.md` was performed to verify content and formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be980fd58832793049e0ea7b4b62e)