### PR TITLE
Add opening chapters: skull discovery and "Video Game Wizards"

### DIFF
--- a/01_ch01.md
+++ b/01_ch01.md
@@ -1,0 +1,34 @@
+# Chapter 1: The Island That Wouldn’t Hold Its Breath
+## Context
+- Timeline position: Present day, early autumn, immediately after a breakup
+- POV: First-person narrator (adjunct professor, 42)
+- Location: Potomac River island below the mansions
+- Key state (before): Raw, restless, avoiding practical decisions
+- Key state (after): Possesses the skull; chooses secrecy over procedure
+- Continuity notes / open threads: Why he keeps it; who he will tell; how he intends to “find the owner”
+
+I went out to the river because there was nowhere else to put myself. The apartment still smelled like her shampoo, which had a daisy on the label but didn’t smell like any flower I knew, more like bright laundry that had never met a hamper. I didn’t want to walk in neighborhoods where everyone was a pair and I was a fraction. I wanted an island, an excuse, a story no one else could inherit.
+
+A Potomac island is not a Caribbean thing. It’s not sand and palms. It’s scruff and stone, a crust of driftwood and half-rotted picnic tables, a few trees that have learned to lean. From my side of the river, you can look up and see old money perched above the bluff, houses that find their way into glossy magazines by the authority of their lawns alone. The island is what the river permits to remain, which is to say: a narrow place that tries to keep its head low.
+
+I brought a backpack I had carried through three apartments and one ill-considered camping trip, and I told myself I was going to look for arrowheads like I had when I was a kid. It was a harmless lie, the kind you make to get yourself out the door. The truth was I wanted to be in a place without a script. The water was low—late summer, early fall, the river doing that restrained, tired glide—and I could wade across without removing my shoes, which I took as a sign that my life was still possible if I didn’t take it too literally.
+
+There are things you can count on when you’re forty-two and newly unpaired: blisters you didn’t expect, a sudden interest in birds you can’t name, the way your own thoughts take up physical space. I walked the edge of the island and thought about my job, which wasn’t really a job, and the men I taught, who were not boys and not yet men and knew it. I thought about the syllabi I’d cobbled together each semester, every class a small audition I kept hoping would lead to a role someone actually paid for.
+
+I saw the skull because it did not belong in the river. I am not a naturalist; I cannot tell a mink from a muskrat unless you hold them up like flashcards. I assumed at first it was something trapped there by water and time, a deer head rinsed clean. It was a rounded dome, pale and dull as chalk, and the jaw was missing. I touched it with a stick like you touch a door handle after a thunderstorm.
+
+I was not prepared for how light it was when I lifted it, the way it felt like a prop rather than the container of everything I’ve been, except for my parents, who have remained our most tenacious witnesses. It fit between my palms. I turned it and watched the water run from the eye sockets, leaving tiny bright channels. If there was a place for fear, it was there, but my first feeling was curiosity. It made me want to know the teeth, the story, the person, to whom the bones belonged. The skull had that quiet, vacant patience of something that has waited out its owners.
+
+There’s a reasonable version of me who would have set it down gently and called the police. That version knows what you are supposed to do, has a wife maybe, or at least a group chat. But I didn’t have a reasonable version of me. I had the version who, as a kid, found a blue jay on the porch and wrapped it in a shoebox and promised it would fly again. I had the version who once lifted a geranium from a restaurant window box because he liked the color. I had the version who believed objects could be redeemed if he made them his problem.
+
+The skull in my hands was a dare. It said: either you will be ordinary, or you will be honest. I chose the third option: I would be neither. I would take it home and figure out whose it was. This was the kind of narrative impulse I told my students not to indulge. This was plot before prudence. But I kept thinking about my brother, and how he would have made a decision on my behalf by now, how he would have stepped into the scene and declared it his, and how I had spent my life following him to the obvious choice and calling it mine.
+
+I wrapped the skull in my sweatshirt. I did not check for dents or cracks. It didn’t feel like a violation, which I tell myself now is evidence of what I was missing. It felt like a petition. The river kept moving. A hawk made a brief circle above the trees and left without telling me anything.
+
+By the time I waded back across, the skull was an anonymous weight in my backpack, the way a secret is always just a few pounds at first. I rinsed my shoes at the shore. I listened for sirens that did not come. I walked home in a stupid glow of purpose, or possibly panic. If you had passed me on the sidewalk, you would have thought I’d finally agreed to go on a date.
+
+At the apartment, I locked the door and cleared a space on the kitchen table. I set the skull down and stared at it. It looked even smaller in the kitchen light, like a museum replica. I put my hand on the smooth crown and felt the quiet gravity of the thing. This was the beginning of something, I told myself. Not a crime. Not a mistake. A beginning.
+
+I opened my laptop and typed: “Potomac found skull what to do.” The search results were unhelpful and insistent. There were laws. There were steps. There were phone numbers. I closed the lid and went to make coffee, as if caffeine could smooth my conscience into a shape I wanted to live inside. The skull waited. It had waited longer.
+
+I did not tell anyone that day. I did not tell anyone the next day. I was not hiding it so much as keeping it warm.

--- a/02_ch02.md
+++ b/02_ch02.md
@@ -1,0 +1,48 @@
+# Chapter 2: Video Game Wizards
+## Context
+- Timeline position: Late 1990s, adolescence
+- POV: First-person narrator
+- Location: Twin brother’s bedroom / local public access studio
+- Key state (before): Narrator still subsumed by his twin’s plans
+- Key state (after): Humiliated but amused; learns the twin’s confidence is a costume
+- Continuity notes / open threads: Twin as spokesperson; narrator’s emerging discomfort with borrowed identity
+
+My brother decided he wanted a public access call-in show about video games, which is like deciding you want to be a cardiologist because you once held someone’s stethoscope. He was fifteen. I was fifteen. We had the same hair, the same face, the same stutter that only I still carried. He said “We can be experts.” I said “We can play a little.” He said “That’s enough.”
+
+The show was called Video Game Wizards, which in his handwriting looked like Video Game Lizard. He spent an entire Saturday making a logo out of construction paper and glitter, then another hour trying to tape it to our TV without my mother noticing. Our parents liked to joke that we were the same person twice; my brother liked to joke that he was the loud half and I was the quiet half. When he signed us up at the community center, he put my name under his without asking. It felt less like permission and more like the way a train moves through a station without stopping.
+
+We didn’t know much about video games, which was, in hindsight, a crucial detail. We had a Super Nintendo and the kind of modest collection that came from begging at Christmas and renting from the video store. We could describe the levels in Donkey Kong Country, the sensation of timing a jump in Super Mario World. We could not, however, explain what a “combo” was, or why anyone cared about a new console release. My brother’s plan was not to be informed; it was to be persuasive. He had the posture of someone auditioning for a job that was his by birthright.
+
+The studio smelled like old carpet and the coffee the station manager kept warm in a pot the color of regret. We were given two folding chairs and a phone on a table between us. The camera was a large presence, a kind of quiet animal. My brother insisted I sit in the middle, which was, as I would learn, a way of making me the lightning rod. If the show failed, I would be the failure. If it succeeded, it would be because he had built it.
+
+He leaned in close and said, “Smile when we go live.” He said it in a voice that made it sound like an instruction you couldn’t disobey.
+
+The show opened with a silence that felt like the moment before a joke is told. The station manager cued us with a finger, and my brother launched into his introduction. “Welcome, gamers, to Video Game Wizards,” he said, as if a roomful of people had been waiting for him all day. “We’re taking your calls, your cheat codes, your hottest tips, your hottest takes.” He made a sweeping gesture that included me. “I’m Tommy, this is—”
+
+“His brother,” I said, because I was not yet sure how to be anything else.
+
+The first call was a teenager who wanted to know how to beat Bowser in Super Mario World. I described the timing for jumping on the piranha plants, which was the kind of advice that sounded helpful because it was almost true. My brother added that if you held down the A button longer, you could jump farther, which is a lie, but said with confidence it sounded like wisdom.
+
+The second call was a man with a deep voice and a laugh that tasted like cigarettes. “You boys really know your stuff,” he said, and then asked us which Mortal Kombat fatality was the best. We did not know Mortal Kombat. We had watched it at a friend’s house once, on a TV so small the blood was a rumor. My brother said “Sub-Zero,” which was one of the few characters he could name. The man laughed again, harder.
+
+By the third call, the pranksters had found us. There is a type of person who watches public access like a hunt, waiting for the weakest animal in the herd. They are not cruel so much as bored, and the Internet had not yet given them a home. They were stuck with us.
+
+“Which one of you is the expert?” a boy asked.
+
+“My brother,” I said, because I was the middle and therefore the target.
+
+“Okay,” the boy said. “The one in the middle… has no dick.”
+
+There was a beat, long enough for the humiliation to arrive and sit down. My brother laughed into the dead air, a sound that was half apology and half armor. The studio camera kept its fixed, unblinking gaze. I could see my own face in the tiny monitor, the way it went blank with no place to put itself. The station manager did not react; this was not the first time a phone had been used for a cheap line.
+
+We took another call, then another. Each one was a trap. They asked for cheats that did not exist. They dared us to pronounce words that weren’t words. One caller asked if we believed Mario and Luigi were lovers. My brother played along, said “Anything is possible in the Mushroom Kingdom,” and people would say later how quick he was, how he didn’t miss a beat. They would not say how I sat in the middle and learned to disappear.
+
+When the hour was over, we left the studio with the tape under my brother’s arm. He walked fast in the parking lot, energized by the tiny engine of having been on TV at all. I was quiet. I wanted to pretend I had never been there.
+
+In the car, he said, “You did fine.”
+
+“Did I?” I asked.
+
+He didn’t answer. He rolled down the window and stuck his hand out into the summer air like a swimmer testing the temperature. He was already planning our next episode. He didn’t know we wouldn’t have one.
+
+That night, I lay in bed and tried to imagine what it was like to be someone who could invent expertise. It seemed like a kind of magic, a thing that made the world sit at your feet and call you wise. It wasn’t magic. It was audacity. And my brother had enough for both of us.


### PR DESCRIPTION
### Motivation
- Create initial chapter files to establish the novel’s throughline and introduce the narrator’s moral choice about the skull.
- Anchor the present-day investigation with a vivid discovery scene on a Potomac island to set tone and stakes.
- Provide an adolescent twin-scene that exposes the narrator’s tendency to be subsumed by his brother and includes the prank-call humiliation that shapes his identity. 
- Keep files small and editable by following the project’s per-file header template for continuity.

### Description
- Add `01_ch01.md` titled “The Island That Wouldn’t Hold Its Breath,” a present-day first-person scene of finding and keeping the skull. 
- Add `02_ch02.md` titled “Video Game Wizards,” a late-1990s first-person scene of a twin-run public-access show and prank calls that target the narrator. 
- Both files include context headers (timeline, POV, location, key state before/after, and continuity notes) consistent with the README guidance. 

### Testing
- No automated tests were run because this is a writing-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bef2b73908327942317144b79cdc5)