### PR TITLE
Add Chapter 3: Dravel Griveway and Mario Derkksen

### DIFF
--- a/03_ch03.md
+++ b/03_ch03.md
@@ -1,0 +1,28 @@
+# Chapter 3: Dravel Griveway and Mario Derkksen
+## Context
+- Timeline position: Late 1990s, adolescence
+- POV: First-person narrator (teenager)
+- Location: Family computer / Prodigy bulletin boards
+- Key state (before): Lonely, eager for attention, newly discovering online flirtation
+- Key state (after): Entranced and wary; learns how fast online personas can tangle
+- Continuity notes / open threads: Who Anna Long is offscreen; whether Dravel Griveway is real; Mario Derkksen’s future appearance
+
+The first time I logged onto Prodigy, the screen looked like a mall directory. There were bright categories, little icons, and a feeling that if you clicked the wrong thing you might be fined. We paid by the minute, which made every blinking cursor feel like a small money leak, the kind my mother would hiss about if she knew. I was fifteen and supposed to be doing homework in the dining room, but the phone cord could only reach so far, and the family computer was wedged between the china cabinet and the window that faced the neighbor’s fence.
+
+I went to the bulletin boards because they felt like a secret room built inside the house. A list of topics: movies, sports, computers, romance. I clicked romance out of curiosity, which is another way of saying loneliness. There were screen names that sounded like pirate ships and soap operas. I made mine neutral, something forgettable, but I learned quickly that you could be anyone if you were willing to type as if you were them.
+
+That’s how I met Dravel Griveway, which was not a person’s name, and therefore was. The profile said she was sixteen, from Ohio, and liked “poetry and denim.” She typed in little bursts, as if she was tapping a pencil between words. I told her I was sixteen too, which was true in a few months, and that I liked books. She asked which ones. I said “all of them,” which was a lie we both understood. We flirted the way you flirt on the early Internet, with emoticons and sentences that leaned too hard on exclamation points. There was a kind of weightlessness to it, like we had been set free from our faces.
+
+We moved the conversation into a private message window, which felt illicit, like stepping into a closet with a stranger who knows your name. We talked about school and what we wore and what we wished we could be. When she said “You sound sweet,” I felt something electric and absurd, like I had been chosen for a part I hadn’t auditioned for. I asked her what Dravel meant. She said it was from a fantasy novel I’d never read. Griveway was made up because her last name was boring. I told her my last name was boring too. We agreed to keep it secret.
+
+It only takes one other person online to create a triangle. Anna Long appeared in a thread about bad teachers, replying to something I wrote about Mr. Mott and his habit of erasing the board with his shirt. She had a sharper voice than Dravel, less playful, more precise. She wrote: “Boys who complain about teachers usually deserve them.” I asked if she was a teacher. She said no, just a student who was tired of other students pretending they were oppressed. I liked her right away, which is to say I wanted her attention.
+
+Anna started messaging me directly, then Dravel, then both of us in a shared thread. It was like a small apartment where all the doors were open. She made a sport of reading our flirtation and commenting on it. “You two are a Hallmark card waiting to happen,” she said. “You should at least make the letters smell like something.” Dravel answered with a string of smiley faces. I asked Anna what she would have them smell like. She said “mothballs and ambition.”
+
+It was through Anna that I met Mario Derkksen, though “met” is not the right word for a screen name that glowed like a warning. Mario was older, or said he was. He wrote in full sentences and quoted scripture the way someone quotes movie lines. He was in the threads about morality, about whether teenagers should date, about whether God cared if you played Mortal Kombat. He was always certain. If someone wrote a joke, Mario would show up and explain why it was wrong. He was a Catholic zealot, or at least a boy who wanted to be one. He said so in his signature: “Pray the rosary daily.”
+
+Anna treated him like a puzzle. She would tag him in threads and ask him questions to see if he would get stuck in the logic of his own answers. “If the Lord is everywhere,” she asked once, “is He in the basement too?” Mario wrote three paragraphs about light and darkness. Anna forwarded them to me and Dravel and added: “He’s in the basement with a flashlight.” We laughed, the three of us, a tiny clique hidden in the glow of CRT glass.
+
+There was a small thrill in being part of a conspiracy, even one that amounted to a few lines of text. It made the evening feel like it belonged to us. Dravel and I still messaged late, our flirtation now a ribbon threaded through everything else. Anna watched and winked. Mario kept firing scripture like a boy on a battlement. I didn’t know if Dravel was real, or if Anna was a boy with a better vocabulary, or if Mario was a lonely man, or if any of us existed beyond the blue light and the sound of my mother washing dishes.
+
+The minute meter ticked in the corner of the screen. I should have logged off. Instead I kept typing, inventing myself in the little box. It was the first place I felt chosen by people I hadn’t met, and maybe that was enough. I didn’t know then how quickly a screen name could become a story you couldn’t climb out of. I only knew that for a little while, I could be sixteen and wanted and anonymous all at once.


### PR DESCRIPTION
### Motivation
- Introduce a late-1990s teenage POV exploring early online flirtation via Prodigy bulletin boards.
- Establish the characters `Dravel Griveway`, `Anna Long`, and `Mario Derkksen` and the dynamics that will echo into later chapters.
- Show how screen names and brief interactions create intimate, tangled narratives for the narrator.
- Provide continuity hooks about the reality of Dravel and Anna and Mario’s potential future role.

### Description
- Add a new chapter file `03_ch03.md` containing context metadata and the full narrative for Chapter 3.
- The chapter depicts the narrator’s first login, private messaging with Dravel, Anna’s witty interventions, and Mario’s doctrinal appearances. 
- Tone and POV are consistent with prior chapters, using first-person teenage perspective and late-90s setting details.
- Keeps open threads about character identities and future intersections for later development.

### Testing
- No automated tests were run for this narrative-only change.
- The change consists solely of adding the new markdown chapter file and does not affect code paths.
- Basic repository status was checked to confirm the new file is present.
- No test failures occurred because no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf03decc083279d00809df39c8ae7)