### PR TITLE
Add Chapter 4: The Puritanical Morbidity in Disguise as Jungle Jimst

### DIFF
--- a/04_ch04.md
+++ b/04_ch04.md
@@ -1,0 +1,26 @@
+# Chapter 4: The Puritanical Morbidity in Disguise as Jungle Jimst
+## Context
+- Timeline position: Mid-1990s, early adolescence
+- POV: First-person narrator (age 14)
+- Location: Parents’ bedroom phone / suburban house
+- Key state (before): Lonely, eager for connection, between online friendships
+- Key state (after): Haunted by a vanished voice; learns the cost of anonymity
+- Continuity notes / open threads: The girl’s identity; how this shapes his later online caution
+
+Anna and I were taking a break, which is a phrase you can only believe in if you’re fourteen and the word “break” sounds like a vacation rather than a cliff. It meant I had gone quiet in the threads for a week, maybe two, and I told myself I wasn’t checking the message boards as often. It meant I was restless and primed for any kind of attention that came my way.
+
+Her screen name was The Puritanical Morbidity in Disguise as Jungle Jimst, which looked like a typo and therefore felt true. On the phone she told me to call her JJ because it was easier on the mouth. I don’t know her real name. She said she was from Minnesota, which conjured snow and big skies and all the kinds of distance that can feel like safety. She said her voice sounded like she’d just come in from the cold. I believed her.
+
+We ended up on the phone because she wrote, “Prodigy is too slow for this.” She sent a number. I hesitated for the length of one breath and then picked up the phone in my parents’ room, the one with the long cord and the heavy receiver. It was late enough that my parents were asleep but not so late that I felt like a criminal. I closed their door and sat on the carpet next to the bed, the cord stretched taut as if the phone might tug me back into my own life.
+
+She answered on the second ring. “You’re real,” she said, as if it was a joke and also a question.
+
+We talked for hours. I gave her the version of myself I wanted to be, a little smarter, a little older. She gave me a version of herself that sparkled. She teased me relentlessly. She made fun of the way I said “um” before answering, the way I hesitated like a car at a four-way stop. “You’re the most cautious boy I’ve ever met,” she said. “I bet you fold your socks in a straight line.” I didn’t know what to do with that, so I laughed and tried to sound casual, as if I didn’t feel exactly seen.
+
+She told me stories about her school, her friends, her mom, a mall with a fountain that people pretended to throw pennies into but mostly just lost them. I told her about my brother, about the public access show, about how I liked to read in the hallway because my room was too loud. She asked if I had a girlfriend and I told her about Anna and how we were on a break. She said, “Lucky for me,” and it felt like a coin dropping into a slot.
+
+At some point the teasing turned warmer, then riskier, the way a light can change without you noticing until the room is different. Her voice dropped. My own did too. There are things you learn about yourself at fourteen that feel like secrets even when nobody is listening. The phone made it safe and immediate at the same time. I didn’t know where she lived, what her face looked like, whether she was telling the truth about any of it. I only knew that she was there, and that she knew my name, and that she was choosing to stay on the line.
+
+When we finally hung up, my ear was hot and my hand was damp. I lay on my parents’ carpet and listened to the house breathe. The next day I expected a message, a call, some sign that the night had been real. Nothing came. I called the number once, then twice, and both times it rang without answer. I never heard from her again.
+
+It was my first lesson in how quickly a person can become a ghost when you only know their voice. I tried to tell myself it didn’t matter, that we were just two kids playing with a phone line. But I kept replaying her laugh, the way she said JJ, the flicker of heat in her voice. I kept thinking about Minnesota like it was a place you could vanish to on purpose. I’d never met her, and yet I missed her in a way that felt like loss. That was a new feeling, and it stayed with me.


### PR DESCRIPTION
### Motivation
- Expand the narrator’s adolescent backstory with a formative late-night phone encounter that informs later online caution. 
- Capture a specific moment of anonymous intimacy and its emotional aftermath to deepen the novel’s throughline about connection and loss. 
- Situate the event in the mid-1990s setting to reinforce the project’s timeline and voice. 

### Description
- Add a new chapter file `04_ch04.md` containing a context header and a first-person scene where a 14-year-old narrator speaks with a caller who uses the screen name `The Puritanical Morbidity in Disguise as Jungle Jimst` (JJ). 
- The chapter details the phone call, the flirtation that turns intimate, and the narrator’s subsequent sense of absence when the caller vanishes. 
- The file is self-contained and follows the repository’s per-file header template to maintain continuity and chunking strategy. 

### Testing
- No automated tests were run because this is a prose-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf25288088327b8e647349c3e2f73)