### PR TITLE
Add Chapter 5: "Smooth Mooth, Clarkey"

### DIFF
--- a/05_ch05.md
+++ b/05_ch05.md
@@ -1,0 +1,30 @@
+# Chapter 5: Smooth Mooth, Clarkey
+## Context
+- Timeline position: Early 1990s, early adolescence
+- POV: First-person narrator (age 13)
+- Location: Gifted program classroom / middle school
+- Key state (before): Uncertain, hoping to blend in, quietly proud to be “gifted”
+- Key state (after): Marked, isolated, carrying a nickname that won’t let go
+- Continuity notes / open threads: Origin of his wariness in groups; how language becomes a trap
+
+We were the gifted kids, which is a label that sounds like a prize but mostly meant we were taken out of class twice a week and asked to solve puzzles in a room that smelled like dry erase markers and old carpet. We were thirteen, which is the year your voice can crack on a word you’ve said a thousand times. I didn’t know yet how much being singled out could feel like being left out.
+
+The gifted program met in a portable, a low building behind the main school where the windows rattled when a bus went by. Our teacher was named Mrs. Clarke. She was the kind of adult who wore vests with a lot of pockets and thought it was funny to call us her “little professors.” She called me Clarkey, which is a nickname you get when your last name is similar to hers and you are the quiet one she wants to coax into talking. I didn’t mind it then. It made me feel chosen.
+
+There was a boy in the class named Aaron who could do mental math like it was a sport and a girl named Lisa who read faster than anyone else, who finished entire novels during the allotted thirty minutes and then looked bored, as if she had been forced to watch a movie on fast-forward. There was me, who had a stutter that seemed to come and go like a weather system. I was fine in my regular classes, but in that portable I felt like my words were on display, lined up like ants for inspection.
+
+The day it happened, Mrs. Clarke had us doing some kind of logic grid, the kind where you match pets to owners and colors to houses. It was supposed to be a warm-up. Aaron finished first and leaned back, smug, which was his posture for most of the year. Mrs. Clarke went to his desk and said, “Smooth move.” It was an adult thing to say, the kind of phrase that makes you feel like you’re in on something older.
+
+I meant to repeat it, a tiny echo to show I was listening, or to borrow her ease. What came out was “smooth mooth, Clarkey,” because my tongue caught, because I was thirteen and my mouth betrayed me, because my brain was half a beat ahead of my lips and thought it could afford the glitch. It landed in the room like a dropped book. For a split second there was silence, and then someone laughed. I don’t know who. It’s always a chorus, never a solo.
+
+“Smooth mooth,” Aaron said, and that was it. The whole room turned the phrase around like a puzzle piece and found where it fit. It fit on me. It fit on my name, which was already close enough to Clarkey to make it sound like a parody. It fit on my stutter. Mrs. Clarke blinked and smiled the way adults do when they don’t want to stop what’s happening but wish it would soften. She went back to the whiteboard. The moment closed, but the echo stayed open.
+
+By the time I walked into the cafeteria later, it was out ahead of me. “Smooth mooth, Clarkey,” someone said under their breath, and their friend laughed into a milk carton. In the hallway, in line at the water fountain, in the library stacks, it followed me like a song you can’t get out of your head. It wasn’t brutal, which would have been easier. It was cheap, easy, fun to say. It was a reflex everyone was invited to share.
+
+I tried to be normal about it. I tried to laugh. I tried to pretend the nickname didn’t make my stomach go tight. The problem with a joke like that is that it doesn’t end; it just moves to other mouths. It migrates. It becomes a way to point at you without having to look directly. I would hear it coming down the hallway before I could tell where it came from. I would feel the beginning of a smile on my face and then swallow it back.
+
+At thirteen, you don’t have a lot of strategies. You either fight it, which means you become a story, or you let it seep into you until it becomes your skin. I chose the second. I became quiet in that room. I stopped raising my hand. I stopped saying anything that might trip over itself. I started watching other people talk, learning where they stumbled and how they saved themselves. I learned to keep my words small and precise, to keep them in a straight line.
+
+Mrs. Clarke called me Clarkey for the rest of the year, and nobody corrected her. I didn’t correct her. I didn’t correct anyone. Smooth mooth, Clarkey became the thread tied to me in that class, and even when I left the portable and went back to the regular halls, I could feel it trailing behind like a loose shoelace. It taught me how a room can decide who you are in a single sentence. It taught me how a mistake can become a name.
+
+I was thirteen. I didn’t know yet how many times I would spend the rest of my life trying to undo the sound of my own voice.


### PR DESCRIPTION
### Motivation
- Continue the memoir arc by adding an adolescent episode that explains a formative social wound.  
- Provide the origin of the nickname “Smooth Mooth, Clarkey” and show how a single slip became a lasting label.  
- Deepen themes of language, identity, and social withdrawal that link the narrator’s youth to later chapters.  
- Supply explicit continuity notes to anchor the event in the book’s timeline and character development.  

### Description
- Added a new markdown file `05_ch05.md` containing Chapter 5 titled “Smooth Mooth, Clarkey.”  
- The chapter is written in first-person from the narrator at age 13 and recounts the gifted-program incident and its aftermath.  
- Top-matter context was included (timeline, POV, location, key state, and continuity notes) to match the style of existing chapters.  
- This is a narrative-only addition and does not modify code or other project files.  

### Testing
- No automated tests were run because this is a content-only change and does not affect executable code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf3785e7083278f5561cd9e753f7e)