### PR TITLE
Add Chapter 6: The Jeep Offer

### DIFF
--- a/06_ch06.md
+++ b/06_ch06.md
@@ -1,0 +1,38 @@
+# Chapter 6: The Jeep Offer
+## Context
+- Timeline position: Early 2000s, early adulthood
+- POV: First-person narrator (age 23)
+- Location: Richmond to Arlington; cheap motels, karaoke bar, Days Inn
+- Key state (before): Restless, broke, desperate to shake his life loose
+- Key state (after): Tethered by a complicated bargain, ashamed but hungry for escape
+- Continuity notes / open threads: The Jeep as a symbol of mobility and debt; narrator’s tendency to accept uneven trades
+
+When I was twenty-three I decided I could solve a life by moving through it fast enough. Richmond to Arlington didn’t feel like a huge distance on a map, but on a bike it felt like a ritual: a way to shake loose the years that had started to calcify. I had been miserable for a long time, not in a dramatic way, just in the dull, persistent way of knowing I was living a life I didn’t recognize and telling myself I deserved it.
+
+My bike was barely fit for the trip. The brakes rubbed. The tires were tired. The only coat I owned was a bulky winter coat that I had stolen from my father’s closet years earlier. It was built for December, not for the September heat I rode through, and it made me sweat and feel like a child wearing his dad’s suit. I carried a backpack with one change of clothes and a toothbrush. Everything else I owned stayed behind like a dare.
+
+I made it in three days. I stayed in the cheapest of cheap motels, the kind where the carpet sticks and the ice bucket has a lid you’d be better off not touching. On the second night I found a karaoke bar next to the Days Inn, its neon sign buzzing in the rain. I had never done karaoke, but I walked in anyway. I told myself I could sing. The truth is I wanted a room that wasn’t mine and a voice that wasn’t the one in my head.
+
+The bar smelled like beer and disinfectant. A man in a cowboy hat was singing “Friends in Low Places” with the wrong kind of sincerity. I put my name on the list and waited, and when it was my turn I picked a song I’d grown up with and knew how to hide inside. I sang. People clapped. It was the first time in a while I felt like I had made the room do something.
+
+Afterward a woman named Lisa came over and said I was good. She had a laugh that landed high and then settled low. She was older than me, forty if she was a day. She was with a friend, a Vietnamese woman whose name I never caught. The friend watched me the way some people watch a show they’ve already decided they won’t like. Lisa bought me a drink. The friend didn’t. I drank it anyway.
+
+We ended up back at the motel. There were two beds and a beige wall lamp that made everything look like a courtroom. I kept my bulky coat on because I didn’t know what else to do with it. Lisa and I made out under the covers, my coat bunching at my elbows, my hands unsure where to go. Her friend lay in the other bed, bored, flipping through channels with the remote. The room hummed with television and awkwardness. The friend was, objectively, hotter, and I did nothing because I didn’t know how to want without permission. Eventually Lisa kissed me on the cheek, and they left.
+
+She kept in touch. She was a phone call that came when I didn’t know who else might call. She told me she had four kids, that she drank too much, that her ex had taken the best furniture. She bought me a journal and told me to write in it. She gave me bottles of alcohol and then called me to ask what I was drinking. She paid for hotel rooms when I came back up to Arlington, the kind of kindness that also felt like a tether.
+
+We slept together not long after, in a room she had rented. I was a virgin. She refused to believe me. “You’re lying,” she said, laughing, as if it were a trick, a compliment. I didn’t correct her. I let her write the story for me because it felt easier than insisting on the truth.
+
+At some point I knew I needed to move on. I wasn’t in love with her, not in the way I wanted to be in love. I was dating someone else on and off, the kind of relationship that existed more as a habit than a plan. Still, Lisa became a person in my orbit, a soft fixed star. When I pulled away, she’d call. When I didn’t answer, she’d text. When I came back, she’d be there with a drink and a joke and a look that made me feel both wanted and already spent.
+
+Then she said she had a Jeep for me. It was old, she said, but it ran. I could have it. It was the first time in years someone offered me a vehicle, a way out that wasn’t powered by my own legs. She said it casually, like the offer was nothing, but I understood right away that it was everything.
+
+We went back and forth for months. She would hint at it, I would try to nail it down. She would say she wanted to see me, I would see her and then, on the way out the door, ask about the Jeep again. I was awkward about it, greedy and ashamed at the same time. I wanted the Jeep so badly it hurt. I told myself it wasn’t really about her, that it was about moving forward, but I could feel the bargain and the imbalance in my stomach.
+
+The person I was dating encouraged me to do what I needed to do to get it. “Do what you need to do,” she said, which was both permission and distance. I wanted to be the kind of person who didn’t take gifts with strings, but I wasn’t that person yet, and I didn’t have any other way to get a car.
+
+In the end her friend called me. The Vietnamese woman I’d met in the motel room. She spoke plainly. She said Lisa had thought that if she gave me a Jeep, I would spend time with her. She said Lisa was hurt, that she felt like I had taken and taken. I listened, and when she was done I said, “So… no Jeep?” I heard myself as I said it and hated the sound, the thinness of it. It was a selfish question, and I had asked it anyway.
+
+That was the end of the Jeep. It was also the end of Lisa, more or less. She called a few more times and then stopped. I kept the journal she’d bought me. I kept the knowledge that I’d traded the idea of a car for a slow, sad kind of intimacy and still come away empty. It wasn’t the worst thing I’ve ever done, but it was a clean, clear version of the worst thing in me: the part that believes if you want something badly enough you can bargain for it with whatever you have on hand.
+
+I never rode that route again. I kept the coat for years, heavy and ill-suited, a reminder of the time I tried to ride myself into a different life and ended up learning how the old life could follow me by other means.


### PR DESCRIPTION
### Motivation
- Add a new chapter to expand the narrator’s early-adulthood arc and show a consequential episode that shapes later behavior. 
- Introduce the Jeep as a recurring symbol of mobility, debt, and transactional intimacy in the protagonist’s life. 
- Provide a self-contained scene that ties into existing continuity and the project’s per-file metadata conventions. 

### Description
- Add new file `06_ch06.md` containing Chapter 6 titled "The Jeep Offer" with a `## Context` header that includes timeline, POV, location, and continuity notes. 
- The chapter narrates a Richmond-to-Arlington bike trip, a karaoke night, a motel encounter with Lisa and her friend, the development of an uneven relationship, and the months-long back-and-forth over an offered Jeep. 
- The file follows the repository’s per-file header template from `README.md` to keep the chapter self-contained and track open threads. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf5e0561c83279967e592eda8ee4d)